### PR TITLE
現在のidとパスワードを入力し、間違っている場合には更新が反映されないように変更

### DIFF
--- a/app/src/presentation/error/index.ts
+++ b/app/src/presentation/error/index.ts
@@ -53,3 +53,12 @@ export class OverflowDataError extends Error {};
  * @extends {Error}
  */
 export class NullDataError extends Error {};
+
+/**
+ * アクセスが不正である場合にthrowされるべきエラークラス
+ *
+ * @export
+ * @class InvalidAccessError
+ * @extends {Error}
+ */
+export class InvalidAccessError extends Error {};

--- a/app/views/pages/admin/setting/index.ejs
+++ b/app/views/pages/admin/setting/index.ejs
@@ -13,6 +13,20 @@
     <main>
       <form action="/admin/setting/update" method="post">
         <input type="hidden" name="_csrf" value="<%= pageData.csrfToken %>">
+
+        <h3>現在のIDとパスワード</h3>
+
+        <div class="form-group">
+          <label for="nowId" class="form-label">現在のID</label>
+          <input class="form-control" type="text" id="nowId" name="nowId">
+        </div>
+        <div class="form-group">
+          <label for="nowPw" class="form-label">現在のパスワード</label>
+          <input class="form-control" type="password" id="nowPw" name="nowPw">
+        </div>
+
+        <h3>変更するIDとパスワード</h3>
+
         <div class="form-group">
           <label for="id" class="form-label">ID名</label>
           <input class="form-control" type="text" id="id" name="id">
@@ -21,6 +35,7 @@
           <label for="pw" class="form-label">パスワード</label>
           <input class="form-control" type="password" id="pw" name="pw">
         </div>
+
         <button type="submit" class="btn btn-outline-warning">更新</button>
       </form>
     </main>


### PR DESCRIPTION
# 現在のidとパスワードを入力し、間違っている場合には更新が反映されないように変更

## 変更内容

### Changed

- 管理者のidとパスワードの変更を行う処理の変更

## 関連issue

Fix #209 
