### PR TITLE
mongodb内のセキュリティアラートの修正

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hotate_server",
-  "version": "0.0.7",
+  "version": "1.2.0",
   "description": "Server used by the service, HOTATE.",
   "main": "index.js",
   "scripts": {

--- a/app/src/interface/test/inMemoryAuthorRepository.ts
+++ b/app/src/interface/test/inMemoryAuthorRepository.ts
@@ -25,7 +25,7 @@ export default class InMemoryAuthorRepository implements IAuthorRepository {
   }
 
   async findByName(name: string | null): Promise<Author | null> {
-    const res = await this.authorCollection.findOne({name});
+    const res = await this.authorCollection.findOne({name: {$eq: name}});
 
     if (res === null) return null;
 
@@ -78,7 +78,7 @@ export default class InMemoryAuthorRepository implements IAuthorRepository {
 
   /** 疑似的に完全一致検索を使用 */
   async searchUsingLike(name: string): Promise<Author[]> {
-    const fetchData = this.authorCollection.find({name});
+    const fetchData = this.authorCollection.find({name: {$eq: name}});
 
     const authors: Author[] = [];
 

--- a/app/src/interface/test/inMemoryBookRepository.ts
+++ b/app/src/interface/test/inMemoryBookRepository.ts
@@ -147,8 +147,8 @@ export default class InMemoryBookRepository implements IBookRepository {
   }
 
   async searchUsingLike(words: string, pageCount: number, margin: PaginationMargin): Promise<{ books: Book[]; count: number; }> {
-    const fetchData = (await this.bookCollection.find({book_name: words}).skip(pageCount * margin.Margin).limit(margin.Margin).toArray()) as bookDocument[];
-    const fetchCount = await this.bookCollection.count({book_name: words});
+    const fetchData = (await this.bookCollection.find({book_name: {$eq: words}}).skip(pageCount * margin.Margin).limit(margin.Margin).toArray()) as bookDocument[];
+    const fetchCount = await this.bookCollection.count({book_name: {$eq: words}});
 
     const books:Book[] = await Promise.all(fetchData.map(async (data) => {
       const fetchAuthorData = await this.authorCollection.findOne({id: data.author_id});
@@ -182,7 +182,7 @@ export default class InMemoryBookRepository implements IBookRepository {
   }
 
   async searchByTag(tagName: string, pageCount: number, margin: PaginationMargin): Promise<{ books: Book[]; count: number; }> {
-    const fetchTag = await this.tagCollection.findOne({name: tagName});
+    const fetchTag = await this.tagCollection.findOne({name: {$eq: tagName}});
 
     if (fetchTag === null) return {books: [], count: 0};
 

--- a/app/src/interface/test/inMemoryPublisherRepository.ts
+++ b/app/src/interface/test/inMemoryPublisherRepository.ts
@@ -25,7 +25,7 @@ export default class InMemoryPublisherRepository implements IPublisherRepository
   }
 
   async findByName(name: string | null): Promise<Publisher | null> {
-    const res = await this.publisherCollection.findOne({name});
+    const res = await this.publisherCollection.findOne({name: {$eq: name}});
 
     if (res === null) return null;
 
@@ -78,7 +78,7 @@ export default class InMemoryPublisherRepository implements IPublisherRepository
 
   /** 疑似的に完全一致検索を使用 */
   async searchUsingLike(name: string): Promise<Publisher[]> {
-    const fetchData = this.publisherCollection.find({name});
+    const fetchData = this.publisherCollection.find({name: {$eq: name}});
 
     const publishers: Publisher[] = [];
 

--- a/app/src/interface/test/inMemoryTagRepository.ts
+++ b/app/src/interface/test/inMemoryTagRepository.ts
@@ -22,7 +22,7 @@ export default class InMemoryTagRepository implements ITagRepository {
   }
 
   async findByName(name: string): Promise<Tag | null> {
-    const res = await this.tagCollection.findOne({name});
+    const res = await this.tagCollection.findOne({name: {$eq: name}});
 
     if (res === null) return null;
 
@@ -36,7 +36,7 @@ export default class InMemoryTagRepository implements ITagRepository {
   }
 
   async isExistCombination(tagId: string, bookId: string): Promise<boolean> {
-    const count = await this.usingTagCollection.count({tag_id: tagId, book_id: bookId});
+    const count = await this.usingTagCollection.count({tag_id: {$eq: tagId}, book_id: {$eq: bookId}});
 
     return count !== 0;
   }
@@ -69,7 +69,7 @@ export default class InMemoryTagRepository implements ITagRepository {
   }
 
   async findById(id: string): Promise<Tag | null> {
-    const res = await this.tagCollection.findOne({id});
+    const res = await this.tagCollection.findOne({id: {$eq: id}});
 
     if (res === null) return null;
 


### PR DESCRIPTION
# mongodb内のセキュリティアラートの修正

## 変更内容

### Fixed

- mongodb内でアラートされていた`Database query built from user-controlled sources`の修正

## その他

今回修正したmongodbはテスト環境で使用されるインメモリDBなので、実際の実行環境には影響ないと思われる