### PR TITLE
書籍の画像の取得APIを変更

### DIFF
--- a/app/public/css/campaign/item.css
+++ b/app/public/css/campaign/item.css
@@ -1,3 +1,7 @@
+body {
+  background-color: #fff;
+}
+
 .campaign-title-box {
   padding: 1rem;
   padding-bottom: 10px;

--- a/app/public/css/item.css
+++ b/app/public/css/item.css
@@ -7,7 +7,7 @@ main {
 }
 
 body {
-  background-color: var(--bg-color)!important;
+  background-color: var(--bg-color);
 }
 
 .item-box {

--- a/app/public/css/item.css
+++ b/app/public/css/item.css
@@ -103,7 +103,7 @@ aside {
 
 .osusume-flex {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 30px;
   overflow: scroll;
 }

--- a/app/src/infrastructure/api/fetchImgFunc.ts
+++ b/app/src/infrastructure/api/fetchImgFunc.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const url = "http://api.openbd.jp/v1/get?isbn=";
+const url = "https://ndlsearch.ndl.go.jp/thumbnail/";
 
 /**
  * ISBNに対応する本の画像データを[openBD](https://openbd.jp/)から取得します。
@@ -12,9 +12,12 @@ const url = "http://api.openbd.jp/v1/get?isbn=";
 export async function getImgLink(isbn: string | null): Promise<string | null> {
   if (isbn === null) return null;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await axios.get(`${url}${isbn}`).then((res) => res.data) as any;
-    return res[0].onix.CollateralDetail.SupportingResource[0].ResourceVersion[0].ResourceLink as string;
+    const formatIsbn = isbn.replace(/-/g, "");
+
+    // 画像が見つからない（xml形式のデータが返ってくる）場合はエラーになるのでそれを利用する
+    await axios.get(`${url}${formatIsbn}.jpg`);
+
+    return `${url}${formatIsbn}.jpg`;
   } catch (e) {
     return null;
   }

--- a/app/src/infrastructure/api/fetchImgFunc.ts
+++ b/app/src/infrastructure/api/fetchImgFunc.ts
@@ -14,6 +14,8 @@ export async function getImgLink(isbn: string | null): Promise<string | null> {
   try {
     const formatIsbn = isbn.replace(/-/g, "");
 
+    if (formatIsbn.length !== 13 || isNaN(Number(formatIsbn))) return null;
+
     // 画像が見つからない（xml形式のデータが返ってくる）場合はエラーになるのでそれを利用する
     await axios.get(`${url}${formatIsbn}.jpg`);
 

--- a/app/src/infrastructure/api/repository/BookImgOpenDBRepository.ts
+++ b/app/src/infrastructure/api/repository/BookImgOpenDBRepository.ts
@@ -1,5 +1,5 @@
 import {IBookImgRepository} from "../../../domain/repository/bookImg/IBookImgRepository";
-import {getImgLink} from "../openbd";
+import {getImgLink} from "../fetchImgFunc";
 
 export default class BookImgOpenDBRepository implements IBookImgRepository {
   public async fetchBookImg(isbn: string): Promise<string | null> {

--- a/app/src/routers/admin/recommendation.ts
+++ b/app/src/routers/admin/recommendation.ts
@@ -157,7 +157,7 @@ recommendationRouter.post("/udpate", csrfProtection, async (req: Request, res: R
         bookComments,
     );
 
-    req.session.status = {type: "Success", mes: "投稿の変更に成功しました。"};
+    req.flash("success", "投稿の変更に成功しました。");
     logger.info("Posting is updated.");
 
     res.redirect("/admin/recommendation/");

--- a/app/views/pages/admin/recommendation/index.ejs
+++ b/app/views/pages/admin/recommendation/index.ejs
@@ -21,6 +21,7 @@
 
     <a href="/admin/" class="tree-button mx-auto my-4">戻る</a>
 
+    <%- include('./../../../components/state-alert', {pageData}) %>
     <%- include('./../../../components/input-js') %>
   </body>
 </html>

--- a/app/views/pages/campaign/item.ejs
+++ b/app/views/pages/campaign/item.ejs
@@ -27,7 +27,7 @@
         <% if (pageData.anyData.recommendation.items.length) { %>
           <aside class="my-4">
             <div class="osusume-title text-center"><i class="bi bi-book me-4"></i>書籍<i class="bi bi-book ms-4"></i></div>
-            <div class="osusume-flex justify-content-center">
+            <div class="osusume-flex">
               <% for (const book of pageData.anyData.recommendation.items) { %>
                 <a class="osusume-book" href="/item/<%= book.book.Id %>">
                   <img src="<%= book.book.ImgLink %>" alt="" data-isbn="<%= book.book.Isbn %>">


### PR DESCRIPTION
# 書籍の画像の取得APIを変更

## 変更内容

### Change

- 書籍の画像を取得するAPIを[国立図書館が提供するAPI](https://ndlsearch.ndl.go.jp/help/api/thumbnail)に変更

### Fixed

- 細かなUI修正

